### PR TITLE
Directory Locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ Highlander is a decorator to help developers ensure that their python
 process is only running once. This is helpful when you have
 a python program running on a set schedule (i.e., a cron) and you do
 not want one run of the program to overlap with another run. Highlander
-accomplishes this by creating a file on disk that contains the current
+accomplishes this by creating a directory containing a file
+on disk that contains the current
 process identifier (PID) and creation time. If Highlander detects that
-a PID file currently exists it reads the PID and creation time from the
-file, checks to see if it exists. If it does exist, it ends the program
+the PID directory currently exists it reads the PID file inside
+it for the PID and creation time and checks to see if that process exists.
+If it does exist, it ends the program
 and logs that the program was already running. If it does not exist,
-Highlander removes the old process information file, creates a new one, and
+Highlander removes the old process information directory and file, creates new ones, and
 executes the function associated with the decorator.
 
 
@@ -24,21 +26,28 @@ Installation
 
 Examples
 ========
+An example using the default directory (i.e., current working directory):
+
     from highlander import one
     
-    @one() # Create a PID file in the current working directory.
-    def long_running_operation():
+    @one()
+    def run():
         ...
         
-        
+    if __name__ == '__main__':
+        run()
+      
+An example using a user-specified directory:
+
     from highlander import one
     
-    @one('/tmp/pid_file') # Create a PID file in a user-specified directory.
-    def long_running_operation():
+    @one('/tmp/.pid')
+    def run():
         ...
+        
+    if __name__ == '__main__':
+        run()
 
 TODO
 ====
 * Add an argument to specify a timeout.
-* Add an exclusive file lock to the process information file. I realize a
-race condition exists without this, but I want to release early and often.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ process is only running once. This is helpful when you have
 a python program running on a set schedule (i.e., a cron) and you do
 not want one run of the program to overlap with another run. Highlander
 accomplishes this by creating a directory containing a file
-on disk that contains the current
-process identifier (PID) and creation time. If Highlander detects that
-the PID directory currently exists it reads the PID file inside
-it for the PID and creation time and checks to see if that process exists.
-If it does exist, it ends the program
+on disk that contains the current process identifier (PID) and 
+creation time. If Highlander detects that the PID directory currently 
+exists it reads the PID file inside it for the PID and creation time
+and checks to see if that process exists. If it does exist, it ends the program
 and logs that the program was already running. If it does not exist,
 Highlander removes the old process information directory and file, creates new ones, and
 executes the function associated with the decorator.
@@ -42,7 +41,7 @@ An example using a user-specified directory:
 
     from highlander import one
     
-    @one('/tmp/.pid')
+    @one('/tmp/my_app/.pid')
     def run():
         ...
         

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Highlander: There can be only one...
 [![Build Status](https://travis-ci.org/chriscannon/highlander.svg?branch=master)](https://travis-ci.org/chriscannon/highlander)
 [![Coverage Status](https://coveralls.io/repos/chriscannon/highlander/badge.svg)](https://coveralls.io/r/chriscannon/highlander)
+[![Downloads](https://img.shields.io/pypi/dm/highlander-one.svg)](https://pypi.python.org/pypi/highlander-one)
 
 About
 =====

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 About
 =====
-Highlander is a decorator to help developers ensure that their python 
+Highlander is a decorator to help developers ensure that their python
 process is only running once. This is helpful when you have
 a python program running on a set schedule (i.e., a cron) and you do
 not want one run of the program to overlap with another run. Highlander
 accomplishes this by creating a directory containing a file
-on disk that contains the current process identifier (PID) and 
-creation time. If Highlander detects that the PID directory currently 
+on disk that contains the current process identifier (PID) and
+creation time. If Highlander detects that the PID directory currently
 exists it reads the PID file inside it for the PID and creation time
 and checks to see if that process exists. If it does exist, it ends the program
 and logs that the program was already running. If it does not exist,
@@ -22,32 +22,28 @@ executes the function associated with the decorator.
 Installation
 ============
     pip install highlander-one
-  
+
 
 Examples
 ========
 An example using the default directory (i.e., current working directory):
 
     from highlander import one
-    
+
     @one()
     def run():
         ...
-        
+
     if __name__ == '__main__':
         run()
-      
+
 An example using a user-specified directory:
 
     from highlander import one
-    
+
     @one('/tmp/my_app/.pid')
     def run():
         ...
-        
+
     if __name__ == '__main__':
         run()
-
-TODO
-====
-* Add an argument to specify a timeout.

--- a/highlander/__init__.py
+++ b/highlander/__init__.py
@@ -1,8 +1,8 @@
 from .highlander import one
-from .exceptions import InvalidPidFileError, PidFileExistsError, InvalidPidDirectoryError
+from .exceptions import InvalidPidFileError, PidFileExistsError
 
 __all__ = [
     'one',
 
-    'InvalidPidFileError', 'PidFileExistsError', 'InvalidPidDirectoryError'
+    'InvalidPidFileError', 'PidFileExistsError'
 ]

--- a/highlander/__init__.py
+++ b/highlander/__init__.py
@@ -1,8 +1,8 @@
 from .highlander import one
-from .exceptions import InvalidPidFileError, PidFileExistsError
+from .exceptions import InvalidPidFileError, PidFileExistsError, InvalidPidDirectoryError
 
 __all__ = [
     'one',
 
-    'InvalidPidFileError', 'PidFileExistsError'
+    'InvalidPidFileError', 'PidFileExistsError', 'InvalidPidDirectoryError'
 ]

--- a/highlander/exceptions.py
+++ b/highlander/exceptions.py
@@ -3,6 +3,3 @@ class InvalidPidFileError(Exception):
 
 class PidFileExistsError(Exception):
     """ An exception when a PID file already exists."""
-
-class InvalidPidDirectoryError(Exception):
-    """ An exception when an invalid PID directory is detected."""

--- a/highlander/exceptions.py
+++ b/highlander/exceptions.py
@@ -3,3 +3,6 @@ class InvalidPidFileError(Exception):
 
 class PidFileExistsError(Exception):
     """ An exception when a PID file already exists."""
+
+class InvalidPidDirectoryError(Exception):
+    """ An exception when an invalid PID directory is detected."""

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -1,3 +1,4 @@
+from errno import EEXIST
 from logging import getLogger
 from os import getcwd, unlink
 from os.path import join, realpath, isfile
@@ -37,7 +38,17 @@ def _is_running(directory):
     :param directory: The PID directory containing the process information.
     :return: Whether or not the process is currently running.
     """
-    if not isfile(str(pid_file)):
+    directory_exists = False
+    try:
+        mkdir(str(directory))
+    except OSError as e:
+        if e.errno == EEXIST:
+            directory_exists = True
+        else:
+            raise e
+
+    if not directory_exists:
+        return False
         return False
 
     pid, create_time = _read_pid_file(pid_file)

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -49,6 +49,10 @@ def _is_running(directory):
 
     if not directory_exists:
         return False
+
+    pid_file = _get_pid_filename(directory)
+
+    if not isfile(pid_file):
         return False
 
     pid, create_time = _read_pid_file(pid_file)

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -1,4 +1,4 @@
-from errno import EEXIST, ENOENT
+from errno import EEXIST
 from logging import getLogger
 from os import getcwd, mkdir
 from os.path import join, realpath, isfile, isdir
@@ -77,6 +77,7 @@ def _is_locked(directory, remove_directory=False):
             raise e
     return False
 
+
 def _read_pid_file(filename):
     """Read the current process information from disk.
     :param filename: The name of the file containing the process information.
@@ -107,6 +108,7 @@ def _delete(directory):
     """Delete the process information directory on disk.
     :param directory: The name of the directory to be deleted.
     """
+    rmtree(str(directory), ignore_errors=True)
 
 
 def _get_pid_filename(directory):

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -96,7 +96,9 @@ def _set_running(directory):
 def _delete(filename):
     """Delete a file on disk.
     :param filename: The name of the file to be deleted.
+def _get_pid_filename(directory):
+    """Return the name of the process information file.
+    :param directory: The name of the directory where the process information file
+    is created.
     """
-    if not isfile(str(filename)):
-        raise InvalidPidFileError()
-    unlink(filename)
+    return realpath(join(str(directory), 'INFO'))

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -52,8 +52,8 @@ def _is_running(directory):
     except NoSuchProcess:
         return _is_locked(directory, True)
 
-    if current.create_time() == create_time:
-        return True
+    if current.create_time() != create_time:
+        return _is_locked(directory, True)
 
     _delete(directory)
     return False

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -87,8 +87,9 @@ def _set_running(directory):
     """Write the current process information to disk.
     :param directory: The name of the directory where the process information will be written.
     """
+    filename = _get_pid_filename(directory)
     if isfile(str(filename)):
-        raise PidFileExistsError()
+        raise PidFileExistsError
 
     p = Process()
     with open(filename, 'w') as f:

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -37,7 +37,7 @@ def one(call, pid_directory=default_location):
 def _is_running(directory):
     """ Determine whether or not the process is currently running.
     :param directory: The PID directory containing the process information.
-    :return: Whether or not the process is currently running.
+    :return: True if there is another process running, False if there is not.
     """
     directory_exists = False
     try:

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -1,7 +1,7 @@
 from errno import EEXIST
 from logging import getLogger
 from os import getcwd, mkdir
-from os.path import join, realpath, isfile
+from os.path import join, realpath, isfile, isdir
 from shutil import rmtree
 
 from psutil import Process, NoSuchProcess
@@ -39,14 +39,8 @@ def _is_running(directory):
     :param directory: The PID directory containing the process information.
     :return: True if there is another process running, False if there is not.
     """
-    directory_exists = False
-    try:
-        mkdir(str(directory))
-    except OSError as e:
-        if e.errno == EEXIST:
-            directory_exists = True
-        else:
-            raise e
+    if not isdir(str(directory)):
+        return _is_locked(directory)
 
     if not directory_exists:
         return False

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -58,6 +58,27 @@ def _is_running(directory):
     return True
 
 
+def _is_locked(directory, remove_directory=False):
+    """ Attempt to acquire the lock through directory creation.
+    :param directory: The PID directory containing the process information.
+    :param remove_directory: Remove the directory before attempting to acquire
+    the lock because we know something went wrong and that the directory exists.
+    :return: True is the lock was acquired, False if it was not.
+    """
+    if remove_directory:
+        try:
+            _delete(directory)
+        except InvalidPidDirectoryError:
+            return True
+
+    try:
+        mkdir(str(directory))
+    except OSError as e:
+        if e.errno == EEXIST:
+            return True
+        else:
+            raise e
+    return False
 
 def _read_pid_file(filename):
     """Read the current process information from disk.

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -7,7 +7,7 @@ from shutil import rmtree
 from psutil import Process, NoSuchProcess
 from funcy import decorator
 
-from .exceptions import InvalidPidFileError, PidFileExistsError, InvalidPidDirectoryError
+from .exceptions import InvalidPidFileError, PidFileExistsError
 
 logger = getLogger(__name__)
 default_location = realpath(join(getcwd(), '.pid'))
@@ -66,10 +66,7 @@ def _is_locked(directory, remove_directory=False):
     :return: True is the lock was acquired, False if it was not.
     """
     if remove_directory:
-        try:
-            _delete(directory)
-        except InvalidPidDirectoryError:
-            return True
+        _delete(directory)
 
     try:
         mkdir(str(directory))
@@ -110,11 +107,6 @@ def _delete(directory):
     """Delete the process information directory on disk.
     :param directory: The name of the directory to be deleted.
     """
-    try:
-        rmtree(str(directory))
-    except OSError as e:
-        if e.errno != ENOENT: # Only throw an error if it's something other than the directory not existing.
-            raise InvalidPidDirectoryError
 
 
 def _get_pid_filename(directory):

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -1,12 +1,13 @@
 from errno import EEXIST
 from logging import getLogger
-from os import getcwd, unlink
+from os import getcwd, mkdir
 from os.path import join, realpath, isfile
+from shutil import rmtree
 
 from psutil import Process, NoSuchProcess
 from funcy import decorator
 
-from .exceptions import InvalidPidFileError, PidFileExistsError
+from .exceptions import InvalidPidFileError, PidFileExistsError, InvalidPidDirectoryError
 
 logger = getLogger(__name__)
 default_location = realpath(join(getcwd(), '.pid'))

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -55,8 +55,8 @@ def _is_running(directory):
     if current.create_time() != create_time:
         return _is_locked(directory, True)
 
-    _delete(directory)
-    return False
+    return True
+
 
 
 def _read_pid_file(filename):

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -12,29 +12,29 @@ default_location = realpath(join(getcwd(), '.pid'))
 
 
 @decorator
-def one(call, pid_file=default_location):
+def one(call, pid_directory=default_location):
     """ Check if the call is already running. If so, bail out. If not, create a
     file that contains the process identifier (PID) and creation time. After call
     has completed, remove the process information file.
     :param call: The original function using the @one decorator.
-    :param pid_file: The name of the file where the process information will be written.
+    :param pid_directory: The name of the directory where the process information will be written.
     :return: The output of the original function.
     """
-    if _is_running(pid_file):
+    if _is_running(pid_directory):
         logger.info('The process is already running.')
         return
 
-    _set_running(pid_file)
+    _set_running(pid_directory)
     try:
         result = call()
     finally:
-        _delete(pid_file)
+        _delete(pid_directory)
     return result
 
 
-def _is_running(pid_file):
+def _is_running(directory):
     """ Determine whether or not the process is currently running.
-    :param pid_file: The PID file containing the process information.
+    :param directory: The PID directory containing the process information.
     :return: Whether or not the process is currently running.
     """
     if not isfile(str(pid_file)):
@@ -50,7 +50,7 @@ def _is_running(pid_file):
     if current.create_time() == create_time:
         return True
 
-    _delete(pid_file)
+    _delete(directory)
     return False
 
 
@@ -70,9 +70,9 @@ def _read_pid_file(filename):
         raise InvalidPidFileError()
 
 
-def _set_running(filename):
+def _set_running(directory):
     """Write the current process information to disk.
-    :param filename: The name of the file where the process information will be written.
+    :param directory: The name of the directory where the process information will be written.
     """
     if isfile(str(filename)):
         raise PidFileExistsError()

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -42,15 +42,10 @@ def _is_running(directory):
     if not isdir(str(directory)):
         return _is_locked(directory)
 
-    if not directory_exists:
-        return False
-
-    pid_file = _get_pid_filename(directory)
-
-    if not isfile(pid_file):
-        return False
-
-    pid, create_time = _read_pid_file(pid_file)
+    try:
+        pid, create_time = _read_pid_file(_get_pid_filename(directory))
+    except InvalidPidFileError:
+        return _is_locked(directory, True)
 
     try:
         current = Process(pid)

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -75,15 +75,12 @@ def _read_pid_file(filename):
     :param filename: The name of the file containing the process information.
     :return: The PID and creation time of the current running process.
     """
-    if not isfile(str(filename)):
-        raise InvalidPidFileError()
-
     try:
-        with open(filename, 'r') as f:
+        with open(str(filename), 'r') as f:
             pid, create_time = f.read().split()
         return int(pid), float(create_time)
-    except ValueError:
-        raise InvalidPidFileError()
+    except (IOError, ValueError):
+        raise InvalidPidFileError
 
 
 def _set_running(directory):

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -1,4 +1,4 @@
-from errno import EEXIST
+from errno import EEXIST, ENOENT
 from logging import getLogger
 from os import getcwd, mkdir
 from os.path import join, realpath, isfile, isdir
@@ -111,9 +111,10 @@ def _delete(directory):
     :param directory: The name of the directory to be deleted.
     """
     try:
-        rmtree(directory)
-    except OSError:
-        raise InvalidPidDirectoryError
+        rmtree(str(directory))
+    except OSError as e:
+        if e.errno != ENOENT: # Only throw an error if it's something other than the directory not existing.
+            raise InvalidPidDirectoryError
 
 
 def _get_pid_filename(directory):

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -50,7 +50,7 @@ def _is_running(directory):
     try:
         current = Process(pid)
     except NoSuchProcess:
-        return False
+        return _is_locked(directory, True)
 
     if current.create_time() == create_time:
         return True

--- a/highlander/highlander.py
+++ b/highlander/highlander.py
@@ -93,9 +93,16 @@ def _set_running(directory):
         f.write('{0} {1:.6f}'.format(p.pid, p.create_time()))
 
 
-def _delete(filename):
-    """Delete a file on disk.
-    :param filename: The name of the file to be deleted.
+def _delete(directory):
+    """Delete the process information directory on disk.
+    :param directory: The name of the directory to be deleted.
+    """
+    try:
+        rmtree(directory)
+    except OSError:
+        raise InvalidPidDirectoryError
+
+
 def _get_pid_filename(directory):
     """Return the name of the process information file.
     :param directory: The name of the directory where the process information file

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-__version__ = '0.1.1'
+__version__ = '0.2.0'
 
 setup(
     name='highlander-one',

--- a/tests/highlander_tests.py
+++ b/tests/highlander_tests.py
@@ -118,7 +118,7 @@ class HighlanderTestCase(TestCase):
                 pid_file.write('{0} 1.1'.format(p.pid))
             self.assertFalse(_is_running(d))
             self.assertFalse(isfile(f))
-            self.assertFalse(isdir(d))
+            self.assertTrue(isdir(d))
         finally:
             if isdir(d):
                 rmtree(d)

--- a/tests/highlander_tests.py
+++ b/tests/highlander_tests.py
@@ -7,7 +7,7 @@ from shutil import rmtree
 from psutil import Process
 
 from highlander import InvalidPidFileError, PidFileExistsError
-from highlander.highlander import _read_pid_file, _delete, _set_running, _is_running, _get_pid_filename
+from highlander.highlander import _read_pid_file, _delete, _set_running, _is_running, _get_pid_filename, _is_locked
 from highlander import one
 
 
@@ -144,6 +144,21 @@ class HighlanderTestCase(TestCase):
 
     def test_other_os_error(self):
         self.assertRaises(OSError, _is_running, 'a' * 1000)
+
+    def test_directory_exists(self):
+        self.assertTrue(_is_locked(mkdtemp()))
+
+    def test_cleanup_invalid_pid_file(self):
+        d = mkdtemp()
+        f = _get_pid_filename(d)
+        try:
+            with open(f, 'w') as pid_file:
+                pid_file.write("#@$!")
+            self.assertFalse(_is_running(d))
+            self.assertFalse(isfile(f))
+            self.assertTrue(isdir(d))
+        finally:
+            rmtree(d)
 
 
 def get_suite():

--- a/tests/highlander_tests.py
+++ b/tests/highlander_tests.py
@@ -138,7 +138,7 @@ class HighlanderTestCase(TestCase):
             def f2():
                 return True
 
-            self.assertIsNone(f1())
+            self.assertEquals(f1(), None)
         finally:
             rmtree(d)
 

--- a/tests/highlander_tests.py
+++ b/tests/highlander_tests.py
@@ -6,7 +6,7 @@ from shutil import rmtree
 
 from psutil import Process
 
-from highlander import InvalidPidFileError, PidFileExistsError, InvalidPidDirectoryError
+from highlander import InvalidPidFileError, PidFileExistsError
 from highlander.highlander import _read_pid_file, _delete, _set_running, _is_running, _get_pid_filename
 from highlander import one
 
@@ -62,9 +62,6 @@ class HighlanderTestCase(TestCase):
         finally:
             if isdir(d):
                 rmtree(d)
-
-    def test_delete_invalid_directory(self):
-        self.assertRaises(InvalidPidDirectoryError, _delete, 'not_a_directory')
 
     def test_running_file_exists(self):
         d = mkdtemp()

--- a/tests/highlander_tests.py
+++ b/tests/highlander_tests.py
@@ -143,7 +143,7 @@ class HighlanderTestCase(TestCase):
         self.assertEquals('/test/INFO', _get_pid_filename('/test'))
 
     def test_other_os_error(self):
-        self.assertRaises(OSError, _is_running, 'a'*1000)
+        self.assertRaises(OSError, _is_running, 'a' * 1000)
 
 
 def get_suite():

--- a/tests/highlander_tests.py
+++ b/tests/highlander_tests.py
@@ -146,7 +146,7 @@ class HighlanderTestCase(TestCase):
         self.assertEquals('/test/INFO', _get_pid_filename('/test'))
 
     def test_other_os_error(self):
-        self.assertRaises(OSError, _is_running, '/')
+        self.assertRaises(OSError, _is_running, 'a'*1000)
 
 
 def get_suite():


### PR DESCRIPTION
To ensure race conditions do not exist I first attempt to create a directory. If it succeeds, I create a PID file inside the directory holding the PID and creation time. If it fails, I know the process is already running so I bail out as per usual.