### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ this means is that when you attempt to run your program it will be unable to
 acquire the lock and your program will not run until you manually intervene and
 delete the lock file. My solution does not have this problem.
 
-3. If you are using the flock Unix tool in conjuction with your program its
+3. If you are using the flock Unix tool in conjunction with your program its
 default behavior is to hang until the lock file is free and then execute the command.
 In my opinion, this is not ideal default behaviour because you could have a ton of
 processes build up over time and waste resources. What Highlander does is essentially skip


### PR DESCRIPTION
@chriscannon, I've corrected a typographical error in the documentation of the [highlander](https://github.com/chriscannon/highlander) project. Specifically, I've changed conjuction to conjunction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.